### PR TITLE
update calendar, and website style to hold wider section for contents

### DIFF
--- a/docs/assets/css/style.css
+++ b/docs/assets/css/style.css
@@ -279,7 +279,7 @@ a:hover small {
   color: #777; }
 
 .wrapper {
-  width: 860px;
+  width: 960px;
   margin: 0 auto; }
 
 blockquote {
@@ -374,7 +374,7 @@ header ul a strong {
   color: #222; }
 
 section {
-  width: 500px;
+  width: 660px;
   float: right;
   padding-bottom: 50px; }
 
@@ -394,7 +394,7 @@ footer {
   bottom: 50px;
   -webkit-font-smoothing: subpixel-antialiased; }
 
-@media print, screen and (max-width: 960px) {
+@media print, screen and (max-width: 1160px) {
   div.wrapper {
     width: auto;
     margin: 0; }
@@ -442,7 +442,7 @@ footer {
   header li, header ul li + li + li {
     width: 33%; } }
 @media print {
-  body {
+    body {
     padding: 0.4in;
     font-size: 12pt;
     color: #444; } }

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -9,34 +9,34 @@ layout: default
 All time is Beijing Time / China Standard Time (UTC + 8). 
 All sessions include Q&A time.
 
-| Time                     | Track    | Speaker | Title                        |
-|--------------------------|----------|----------------------------------------|
+| Time                     | Track    | Speaker  
+|--------------------------|----------|---------
 | **Thursday, 2020-10-15** |          |
-| 7:45-8:00 AM           | Opening Remark | 
-| 8:00-8:55 AM           | Keynote Talk   | Dr. Robert Gentleman | 
-| 9:00-9:55 AM           | Invited Talks  | |
-| 10:00-10:15 AM         | Break          | |
-| 10:15-10:45 AM         | Contributed Talks | |
-| 10:50-11:45 AM         | workshop       | |
+| 7:45-8:00 AM           | Opening Remark | Dr. Martin Morgan
+| 8:00-8:55 AM           | Keynote Talk   | Dr. Robert Gentleman 
+| 9:00-9:55 AM           | Invited Talks  | Drs. Lihua Julie Zhu, Qiangfeng Zhang 
+| 10:00-10:15 AM         | Break          | 
+| 10:15-10:45 AM         | Contributed Talks |
+| 10:50-11:45 AM         | workshop       |
 
 | **Friday, 2020-10-16**   |          |
-| 8:00-9:55 AM           | Invited Talks  | |
-| 10:00-10:15 AM         | Break          | |
-| 10:15-10:45 AM         | Contributed Talks | |
-| 10:50-11:45 AM         | workshop       | |
+| 8:00-9:55 AM           | Invited Talks  | Drs. Saskia Freytag, Kai Ye, Lin Hou, Koki Tsuyuzaki 
+| 10:00-10:15 AM         | Break          | 
+| 10:15-10:45 AM         | Contributed Talks |
+| 10:50-11:45 AM         | workshop       |
 | **Saturday, 2020-10-17** |          |
-| 9:00-9:55 AM           | Keynote Talk   | Dr. Yi Xing | 
-| 10:00-10:55 AM           | Invited Talks  | |
-| 11:00-11:15 AM         | Break          | |
-| 11:15-11:45 AM         | Contributed Talks | |
-| 11:50-12:45 AM         | workshop       | |
+| 9:00-9:55 AM           | Keynote Talk   | Dr. Yi Xing  
+| 10:00-10:55 AM           | Invited Talks  | Dr. Charity Law, Guangchuang Yu 
+| 11:00-11:15 AM         | Break          | 
+| 11:15-11:45 AM         | Contributed Talks | 
+| 11:50-12:45 AM         | workshop       | 
 | **Sunday, 2020-10-18**   |          |
-| 9:00-9:55 AM           | Keynote Talk   | Dr. Xuegong Zhang | 
-| 10:00-10:55 AM         | Invited Talks  | |
-| 11:00-11:15 AM         | Break          | |
-| 11:15-11:45 AM         | Contributed Talks | |
-| 11:50-12:45 AM         | Workshop       | |
-| 12:50-13:00 AM         | Closing Remark | |
+| 9:00-9:55 AM           | Keynote Talk   | Dr. Xuegong Zhang 
+| 10:00-10:55 AM         | Invited Talks  | Dr. Tingting Li 
+| 11:00-11:15 AM         | Break          | 
+| 11:15-11:45 AM         | Contributed Talks |
+| 11:50-12:45 AM         | Workshop       |
+| 12:50-13:00 AM         | Closing Remark |
 
 # Shared calendar
 <iframe src="https://teamup.com/ks8z1bgro22peqx8e8?showLogo=0&showSearch=1&showProfileAndInfo=0&showSidepanel=1&disableSidepanel=0&showTitle=0&showViewSelector=1&showMenu=1&showAgendaHeader=1&showAgendaDetails=0&showYearViewHeader=1" width="100%" height="800px" style="border: 1px solid #cccccc" frameborder="0"></iframe>

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -4,10 +4,17 @@ layout: default
 
 {% include header.md %}
 
-# Agenda
+# Calendar agenda
 
-All time is Beijing Time / China Standard Time (UTC + 8). 
+Schedule is based on Beijing Time / China Standard Time (UTC + 8),
+Please change to your preferred "Time zone" in this interactive
+calendar. 
+
 All sessions include Q&A time.
+
+<iframe src="https://teamup.com/ks8z1bgro22peqx8e8?showLogo=0&showSearch=1&showProfileAndInfo=0&showSidepanel=1&disableSidepanel=0&showTitle=0&showViewSelector=1&showMenu=1&showAgendaHeader=1&showAgendaDetails=0&showYearViewHeader=1" width="100%" height="800px" style="border: 1px solid #cccccc" frameborder="0"></iframe>
+
+# Agenda
 
 | Time                     | Track    | Speaker  
 |--------------------------|----------|---------
@@ -38,5 +45,3 @@ All sessions include Q&A time.
 | 11:50-12:45 AM         | Workshop       |
 | 12:50-13:00 AM         | Closing Remark |
 
-# Shared calendar
-<iframe src="https://teamup.com/ks8z1bgro22peqx8e8?showLogo=0&showSearch=1&showProfileAndInfo=0&showSidepanel=1&disableSidepanel=0&showTitle=0&showViewSelector=1&showMenu=1&showAgendaHeader=1&showAgendaDetails=0&showYearViewHeader=1" width="100%" height="800px" style="border: 1px solid #cccccc" frameborder="0"></iframe>


### PR DESCRIPTION
Fixed the start date at Oct. 15th, and it shows "agenda" view as default, users can toggle between "Day/4 Day /Month/Agenda" views, and choose a preferred timezone.

Timeslots drafted for all speakers, can be modified at any time. Titles and abstracts for those who responded are added. 